### PR TITLE
Add support for static builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,12 @@ jobs:
       - run: cargo clippy --all-targets -- -D warnings
       - run: cargo fmt --all -- --check
       - run: cargo doc --no-deps
+  static-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker build --file docker/builder.Dockerfile --tag nitro-tpm-tools-builder .
+      - run: docker run --rm --tty --volume cargo-cache:/root/.cargo/registry --volume $PWD:/mnt nitro-tpm-tools-builder cargo build --bins --examples --locked
+      - run: readelf -l ./target/debug/nitro-tpm-attest | grep -q "INTERP" && exit 1 || exit 0
+      - run: readelf -l ./target/debug/nitro-tpm-pcr-compute | grep -q "INTERP" && exit 1 || exit 0
+      - run: readelf -l ./target/debug/examples/nitro-tpm-kms-decrypt | grep -q "INTERP" && exit 1 || exit 0

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ A collection of utilities for working with NitroTPM attestation.
 
 For more information about each tool, see the respective README files.
 
+## Static Builds
+
+For static linking requirements, a Docker-based build environment is provided that can be used to statically link the TPM2 Software Stack (TSS2) and other dependencies.
+
+```console
+docker build --file docker/builder.Dockerfile --tag nitro-tpm-tools-builder .
+docker run --rm --tty --volume cargo-cache:/root/.cargo/registry --volume $PWD:/mnt nitro-tpm-tools-builder cargo build --bins --release
+```
+
 ## Security
 
 See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.

--- a/docker/builder.Dockerfile
+++ b/docker/builder.Dockerfile
@@ -1,0 +1,44 @@
+FROM --platform=$TARGETPLATFORM rust:1.90-alpine3.22
+
+RUN apk add --no-cache \
+    build-base \
+    curl \
+    pkgconf \
+    linux-headers \
+    openssl-dev \
+    openssl-libs-static
+
+WORKDIR /tmp
+ARG TPM2_TSS_VERSION=4.1.3
+RUN curl --location "https://github.com/tpm2-software/tpm2-tss/releases/download/${TPM2_TSS_VERSION}/tpm2-tss-${TPM2_TSS_VERSION}.tar.gz" --output tpm2-tss-${TPM2_TSS_VERSION}.tar.gz
+RUN tar xz --file tpm2-tss-${TPM2_TSS_VERSION}.tar.gz
+RUN rm tpm2-tss-${TPM2_TSS_VERSION}.tar.gz
+
+WORKDIR /tmp/tpm2-tss-${TPM2_TSS_VERSION}
+RUN ./configure \
+    --prefix=/usr/local \
+    --disable-shared \
+    --enable-nodl \
+    --disable-fapi \
+    --disable-vendor \
+    --disable-policy \
+    --enable-tcti-device \
+    --disable-tcti-mssim \
+    --disable-tcti-swtpm \
+    --disable-tcti-pcap \
+    --disable-tcti-libtpms \
+    --disable-tcti-cmd \
+    --disable-tcti-spi-helper \
+    --disable-tcti-spi-ftdi \
+    --disable-tcti-i2c-helper \
+    --disable-tcti-i2c-ftdi \
+    --disable-weakcrypto \
+    --disable-doxygen-doc
+RUN make --jobs $(nproc)
+RUN make install
+
+WORKDIR /tmp
+RUN rm -r tpm2-tss-${TPM2_TSS_VERSION}
+
+WORKDIR /mnt
+ENV PKG_CONFIG_ALL_STATIC 1

--- a/nitro-tpm-attest/build.rs
+++ b/nitro-tpm-attest/build.rs
@@ -16,4 +16,7 @@ fn main() {
         tss_version_requirement.matches(&tss_version),
         "TPM2 Software Stack (TSS) version {tss_version} not supported, version requirement: {tss_version_requirement}",
     );
+
+    // Allow static linking
+    println!("cargo:rustc-link-arg=-ltss2-tcti-device");
 }


### PR DESCRIPTION
This adds a Docker builder environment to enable static linking of the nitro-tpm-attest package with tpm2-tss and other dependencies.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
