### PR TITLE
Update rust dependency licenses for 1.1.0 release

### DIFF
--- a/LICENSES/THIRD_PARTY_LICENSES_RUST_CRATES.html
+++ b/LICENSES/THIRD_PARTY_LICENSES_RUST_CRATES.html
@@ -44,8 +44,8 @@
     
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (191)</li>
-            <li><a href="#MIT">MIT License</a> (48)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (194)</li>
+            <li><a href="#MIT">MIT License</a> (45)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (19)</li>
             <li><a href="#ISC">ISC License</a> (7)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (1)</li>
@@ -58,199 +58,8 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-credential-types 1.2.3</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-async 1.2.5</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-http 0.62.1</a></li>
-                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-observability 0.1.3</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-query 0.60.7</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime 1.8.3</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-types 1.3.7</a></li>
-                </ul>
-                <pre class="license-text">
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
-
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
-
-   1. Definitions.
-
-      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
-
-      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      &quot;control&quot; means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      &quot;Source&quot; form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      &quot;Object&quot; form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      &quot;Work&quot; shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      &quot;Contribution&quot; shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
-
-      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="Apache-2.0">Apache License 2.0</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide ">miniz_oxide 0.8.9</a></li>
                     <li><a href=" https://github.com/taiki-e/pin-project-lite ">pin-project-lite 0.2.16</a></li>
-                    <li><a href=" https://github.com/time-rs/time ">time-core 0.1.4</a></li>
-                    <li><a href=" https://github.com/time-rs/time ">time 0.3.41</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -855,7 +664,7 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/jhpratt/deranged ">deranged 0.4.0</a></li>
+                    <li><a href=" https://github.com/jhpratt/deranged ">deranged 0.5.5</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -1065,19 +874,17 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/google/authenticode-rs ">authenticode 0.4.3</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-sigv4 1.3.3</a></li>
+                    <li><a href=" https://github.com/google/authenticode-rs ">authenticode 0.5.0</a></li>
                     <li><a href=" https://github.com/enarx/flagset ">flagset 0.4.7</a></li>
                     <li><a href=" https://github.com/Devolutions/picky-rs ">picky-asn1-der 0.4.1</a></li>
-                    <li><a href=" https://github.com/Devolutions/picky-rs ">picky-asn1-der 0.5.2</a></li>
+                    <li><a href=" https://github.com/Devolutions/picky-rs ">picky-asn1-der 0.5.4</a></li>
                     <li><a href=" https://github.com/Devolutions/picky-rs ">picky-asn1-x509 0.12.0</a></li>
                     <li><a href=" https://github.com/Devolutions/picky-rs ">picky-asn1 0.10.1</a></li>
                     <li><a href=" https://github.com/Devolutions/picky-rs ">picky-asn1 0.8.0</a></li>
-                    <li><a href=" https://github.com/nvzqz/static-assertions-rs ">static_assertions 1.1.0</a></li>
                     <li><a href=" https://github.com/parallaxsecond/rust-tss-esapi ">tss-esapi-sys 0.5.0</a></li>
                     <li><a href=" https://github.com/parallaxsecond/rust-tss-esapi ">tss-esapi 7.6.0</a></li>
                     <li><a href=" https://github.com/hsivonen/utf8_iter ">utf8_iter 1.0.4</a></li>
-                    <li><a href=" https://github.com/RustCrypto/utils/tree/master/zeroize ">zeroize 1.8.1</a></li>
+                    <li><a href=" https://github.com/RustCrypto/utils ">zeroize 1.8.2</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils/tree/master/zeroize/derive ">zeroize_derive 1.4.2</a></li>
                 </ul>
                 <pre class="license-text">
@@ -1288,7 +1095,235 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/VoidStarKat/half-rs ">half 2.6.0</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/target-lexicon ">target-lexicon 0.12.16</a></li>
+                </ul>
+                <pre class="license-text">
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      &quot;control&quot; means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      &quot;Source&quot; form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      &quot;Object&quot; form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      &quot;Work&quot; shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      &quot;Contribution&quot; shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
+      replaced with your own identifying information. (Don&#x27;t include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same &quot;printed page&quot; as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+--- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 (&quot;Combined Software&quot;) and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/VoidStarKat/half-rs ">half 2.7.1</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -1472,7 +1507,8 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.25</a></li>
+                    <li><a href=" https://github.com/google/zerocopy ">zerocopy-derive 0.8.30</a></li>
+                    <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.30</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -1893,25 +1929,25 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstream 0.6.19</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstream 0.6.21</a></li>
                     <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-parse 0.2.7</a></li>
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-query 1.1.3</a></li>
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.11</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-query 1.1.5</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.13</a></li>
                     <li><a href=" https://github.com/dzamlo/rust-bitfield ">bitfield 0.14.0</a></li>
-                    <li><a href=" https://github.com/clap-rs/clap ">clap 4.5.40</a></li>
-                    <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.5.40</a></li>
-                    <li><a href=" https://github.com/clap-rs/clap ">clap_derive 4.5.40</a></li>
-                    <li><a href=" https://github.com/clap-rs/clap ">clap_lex 0.7.5</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap 4.5.53</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.5.53</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap_derive 4.5.49</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap_lex 0.7.6</a></li>
                     <li><a href=" https://github.com/rust-cli/anstyle.git ">colorchoice 1.0.4</a></li>
-                    <li><a href=" https://github.com/srijs/rust-crc32fast ">crc32fast 1.4.2</a></li>
-                    <li><a href=" https://github.com/rust-cli/env_logger ">env_filter 0.1.3</a></li>
+                    <li><a href=" https://github.com/srijs/rust-crc32fast ">crc32fast 1.5.0</a></li>
+                    <li><a href=" https://github.com/rust-cli/env_logger ">env_filter 0.1.4</a></li>
                     <li><a href=" https://github.com/rust-cli/env_logger ">env_logger 0.11.8</a></li>
                     <li><a href=" https://github.com/sfackler/foreign-types ">foreign-types-shared 0.1.1</a></li>
                     <li><a href=" https://github.com/sfackler/foreign-types ">foreign-types 0.3.2</a></li>
                     <li><a href=" https://github.com/KokaKiwi/rust-hex ">hex 0.4.3</a></li>
-                    <li><a href=" https://github.com/polyfill-rs/is_terminal_polyfill ">is_terminal_polyfill 1.70.1</a></li>
+                    <li><a href=" https://github.com/polyfill-rs/is_terminal_polyfill ">is_terminal_polyfill 1.70.2</a></li>
                     <li><a href=" https://crates.io/crates/openssl-macros ">openssl-macros 0.1.1</a></li>
-                    <li><a href=" https://github.com/sfackler/rust-openssl ">openssl 0.10.73</a></li>
+                    <li><a href=" https://github.com/rust-openssl/rust-openssl ">openssl 0.10.75</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -2121,10 +2157,10 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-kms 1.76.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sso 1.73.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-ssooidc 1.74.0</a></li>
-                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sts 1.74.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-kms 1.77.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sso 1.74.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-ssooidc 1.75.0</a></li>
+                    <li><a href=" https://github.com/awslabs/aws-sdk-rust ">aws-sdk-sts 1.76.0</a></li>
                 </ul>
                 <pre class="license-text">                                Apache License
                            Version 2.0, January 2004
@@ -2334,21 +2370,19 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.98</a></li>
+                    <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.100</a></li>
                     <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.15</a></li>
-                    <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.173</a></li>
-                    <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.95</a></li>
-                    <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.40</a></li>
+                    <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.177</a></li>
+                    <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.103</a></li>
+                    <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.42</a></li>
                     <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.20</a></li>
-                    <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.26</a></li>
-                    <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.219</a></li>
-                    <li><a href=" https://github.com/serde-rs/bytes ">serde_bytes 0.11.17</a></li>
-                    <li><a href=" https://github.com/serde-rs/serde ">serde_derive 1.0.219</a></li>
-                    <li><a href=" https://github.com/serde-rs/json ">serde_json 1.0.140</a></li>
-                    <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.103</a></li>
-                    <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 2.0.12</a></li>
-                    <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 2.0.12</a></li>
-                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.18</a></li>
+                    <li><a href=" https://github.com/dtolnay/semver ">semver 1.0.27</a></li>
+                    <li><a href=" https://github.com/serde-rs/serde ">serde 1.0.228</a></li>
+                    <li><a href=" https://github.com/serde-rs/bytes ">serde_bytes 0.11.19</a></li>
+                    <li><a href=" https://github.com/serde-rs/serde ">serde_core 1.0.228</a></li>
+                    <li><a href=" https://github.com/serde-rs/serde ">serde_derive 1.0.228</a></li>
+                    <li><a href=" https://github.com/serde-rs/json ">serde_json 1.0.145</a></li>
+                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.22</a></li>
                     <li><a href=" https://github.com/alacritty/vte ">utf8parse 0.2.2</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
@@ -2747,7 +2781,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/paholg/typenum ">typenum 1.18.0</a></li>
+                    <li><a href=" https://github.com/paholg/typenum ">typenum 1.19.0</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -2956,7 +2990,7 @@ limitations under the License.</pre>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/hyperium/http ">http 0.2.12</a></li>
-                    <li><a href=" https://github.com/hyperium/http ">http 1.3.1</a></li>
+                    <li><a href=" https://github.com/hyperium/http ">http 1.4.0</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -3166,7 +3200,7 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/rustls/tokio-rustls ">tokio-rustls 0.24.1</a></li>
-                    <li><a href=" https://github.com/rustls/tokio-rustls ">tokio-rustls 0.26.2</a></li>
+                    <li><a href=" https://github.com/rustls/tokio-rustls ">tokio-rustls 0.26.4</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -3793,7 +3827,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rustls/pki-types ">rustls-pki-types 1.12.0</a></li>
+                    <li><a href=" https://github.com/rustls/pki-types ">rustls-pki-types 1.13.0</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -4003,7 +4037,7 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/UnnecessaryEngineering/oid ">oid 0.2.1</a></li>
-                    <li><a href=" https://github.com/RustCrypto/RSA ">rsa 0.9.8</a></li>
+                    <li><a href=" https://github.com/RustCrypto/RSA ">rsa 0.9.9</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -4212,65 +4246,67 @@ limitations under the License.</pre>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/smol-rs/atomic-waker ">atomic-waker 1.1.2</a></li>
-                    <li><a href=" https://github.com/cuviper/autocfg ">autocfg 1.4.0</a></li>
+                    <li><a href=" https://github.com/cuviper/autocfg ">autocfg 1.5.0</a></li>
                     <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.21.7</a></li>
                     <li><a href=" https://github.com/bitflags/bitflags ">bitflags 1.3.2</a></li>
-                    <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.9.1</a></li>
+                    <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.10.0</a></li>
                     <li><a href=" https://github.com/vorner/bytes-utils ">bytes-utils 0.1.4</a></li>
-                    <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.27</a></li>
-                    <li><a href=" https://github.com/rust-lang/cfg-if ">cfg-if 1.0.1</a></li>
+                    <li><a href=" https://github.com/rust-lang/cc-rs ">cc 1.2.47</a></li>
+                    <li><a href=" https://github.com/rust-lang/cfg-if ">cfg-if 1.0.4</a></li>
                     <li><a href=" https://github.com/rust-lang/cmake-rs ">cmake 0.1.54</a></li>
                     <li><a href=" https://github.com/yaahc/displaydoc ">displaydoc 0.2.5</a></li>
                     <li><a href=" https://github.com/rayon-rs/either ">either 1.15.0</a></li>
                     <li><a href=" https://github.com/indexmap-rs/equivalent ">equivalent 1.0.2</a></li>
                     <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.3.0</a></li>
-                    <li><a href=" https://github.com/rust-lang/flate2-rs ">flate2 1.1.2</a></li>
+                    <li><a href=" https://github.com/rust-lang/cc-rs ">find-msvc-tools 0.1.5</a></li>
+                    <li><a href=" https://github.com/rust-lang/flate2-rs ">flate2 1.1.5</a></li>
                     <li><a href=" https://github.com/servo/rust-fnv ">fnv 1.0.7</a></li>
-                    <li><a href=" https://github.com/servo/rust-url ">form_urlencoded 1.2.1</a></li>
-                    <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.15.4</a></li>
+                    <li><a href=" https://github.com/servo/rust-url ">form_urlencoded 1.2.2</a></li>
+                    <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.16.1</a></li>
                     <li><a href=" https://github.com/withoutboats/heck ">heck 0.5.0</a></li>
                     <li><a href=" https://github.com/seanmonstar/httparse ">httparse 1.10.1</a></li>
                     <li><a href=" https://github.com/rustls/hyper-rustls ">hyper-rustls 0.24.2</a></li>
                     <li><a href=" https://github.com/rustls/hyper-rustls ">hyper-rustls 0.27.7</a></li>
-                    <li><a href=" https://github.com/servo/rust-url/ ">idna 1.0.3</a></li>
+                    <li><a href=" https://github.com/servo/rust-url/ ">idna 1.1.0</a></li>
                     <li><a href=" https://github.com/hsivonen/idna_adapter ">idna_adapter 1.2.1</a></li>
-                    <li><a href=" https://github.com/indexmap-rs/indexmap ">indexmap 2.9.0</a></li>
-                    <li><a href=" https://github.com/rust-lang/jobserver-rs ">jobserver 0.1.33</a></li>
+                    <li><a href=" https://github.com/indexmap-rs/indexmap ">indexmap 2.12.1</a></li>
+                    <li><a href=" https://github.com/rust-lang/jobserver-rs ">jobserver 0.1.34</a></li>
                     <li><a href=" https://github.com/rust-lang-nursery/lazy-static.rs ">lazy_static 1.5.0</a></li>
-                    <li><a href=" https://github.com/Amanieu/parking_lot ">lock_api 0.4.13</a></li>
-                    <li><a href=" https://github.com/rust-lang/log ">log 0.4.27</a></li>
-                    <li><a href=" https://github.com/dignifiedquire/num-bigint ">num-bigint-dig 0.8.4</a></li>
+                    <li><a href=" https://github.com/Amanieu/parking_lot ">lock_api 0.4.14</a></li>
+                    <li><a href=" https://github.com/rust-lang/log ">log 0.4.28</a></li>
+                    <li><a href=" https://github.com/dignifiedquire/num-bigint ">num-bigint-dig 0.8.6</a></li>
                     <li><a href=" https://github.com/rust-num/num-derive ">num-derive 0.4.2</a></li>
                     <li><a href=" https://github.com/rust-num/num-integer ">num-integer 0.1.46</a></li>
                     <li><a href=" https://github.com/rust-num/num-iter ">num-iter 0.1.45</a></li>
                     <li><a href=" https://github.com/rust-num/num-traits ">num-traits 0.2.19</a></li>
-                    <li><a href=" https://github.com/gimli-rs/object ">object 0.36.7</a></li>
+                    <li><a href=" https://github.com/gimli-rs/object ">object 0.37.3</a></li>
                     <li><a href=" https://github.com/matklad/once_cell ">once_cell 1.21.3</a></li>
                     <li><a href=" https://github.com/alexcrichton/openssl-probe ">openssl-probe 0.1.6</a></li>
-                    <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot 0.12.4</a></li>
-                    <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot_core 0.9.11</a></li>
-                    <li><a href=" https://github.com/servo/rust-url/ ">percent-encoding 2.3.1</a></li>
+                    <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot 0.12.5</a></li>
+                    <li><a href=" https://github.com/Amanieu/parking_lot ">parking_lot_core 0.9.12</a></li>
+                    <li><a href=" https://github.com/servo/rust-url/ ">percent-encoding 2.3.2</a></li>
                     <li><a href=" https://github.com/rust-lang/pkg-config-rs ">pkg-config 0.3.32</a></li>
-                    <li><a href=" https://github.com/rust-lang/regex/tree/master/regex-automata ">regex-automata 0.4.9</a></li>
-                    <li><a href=" https://github.com/rust-lang/regex/tree/master/regex-lite ">regex-lite 0.1.6</a></li>
-                    <li><a href=" https://github.com/rust-lang/regex/tree/master/regex-syntax ">regex-syntax 0.8.5</a></li>
-                    <li><a href=" https://github.com/rust-lang/regex ">regex 1.11.1</a></li>
+                    <li><a href=" https://github.com/rust-lang/regex ">regex-automata 0.4.13</a></li>
+                    <li><a href=" https://github.com/rust-lang/regex ">regex-lite 0.1.8</a></li>
+                    <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.8.8</a></li>
+                    <li><a href=" https://github.com/rust-lang/regex ">regex 1.12.2</a></li>
                     <li><a href=" https://github.com/briansmith/ring ">ring 0.17.14</a></li>
                     <li><a href=" https://github.com/djc/rustc-version-rs ">rustc_version 0.4.1</a></li>
                     <li><a href=" https://github.com/ctz/rustls-native-certs ">rustls-native-certs 0.6.3</a></li>
-                    <li><a href=" https://github.com/rustls/rustls-native-certs ">rustls-native-certs 0.8.1</a></li>
+                    <li><a href=" https://github.com/rustls/rustls-native-certs ">rustls-native-certs 0.8.2</a></li>
                     <li><a href=" https://github.com/rustls/pemfile ">rustls-pemfile 1.0.4</a></li>
                     <li><a href=" https://github.com/rustls/rustls ">rustls 0.21.12</a></li>
-                    <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.28</a></li>
+                    <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.35</a></li>
                     <li><a href=" https://github.com/bluss/scopeguard ">scopeguard 1.2.0</a></li>
                     <li><a href=" https://github.com/rustls/sct.rs ">sct 0.7.1</a></li>
                     <li><a href=" https://github.com/pyfisch/cbor ">serde_cbor 0.11.2</a></li>
-                    <li><a href=" https://github.com/vorner/signal-hook ">signal-hook-registry 1.4.5</a></li>
+                    <li><a href=" https://github.com/vorner/signal-hook ">signal-hook-registry 1.4.7</a></li>
                     <li><a href=" https://github.com/servo/rust-smallvec ">smallvec 1.15.1</a></li>
                     <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.5.10</a></li>
-                    <li><a href=" https://github.com/storyyeller/stable_deref_trait ">stable_deref_trait 1.2.0</a></li>
-                    <li><a href=" https://github.com/servo/rust-url ">url 2.5.4</a></li>
-                    <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.17.0</a></li>
+                    <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.6.1</a></li>
+                    <li><a href=" https://github.com/storyyeller/stable_deref_trait ">stable_deref_trait 1.2.1</a></li>
+                    <li><a href=" https://github.com/servo/rust-url ">url 2.5.7</a></li>
+                    <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.18.1</a></li>
                     <li><a href=" https://github.com/SergioBenitez/version_check ">version_check 0.9.5</a></li>
                     <li><a href=" https://github.com/RazrFalcon/xmlparser ">xmlparser 0.13.6</a></li>
                 </ul>
@@ -4485,7 +4521,7 @@ limitations under the License.
                     <li><a href=" https://github.com/RustCrypto/utils ">block-buffer 0.10.4</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/const-oid ">const-oid 0.9.6</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">cpufeatures 0.2.17</a></li>
-                    <li><a href=" https://github.com/RustCrypto/traits ">crypto-common 0.1.6</a></li>
+                    <li><a href=" https://github.com/RustCrypto/traits ">crypto-common 0.1.7</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/der ">der 0.7.10</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/der/derive ">der_derive 0.7.3</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">digest 0.10.7</a></li>
@@ -6075,18 +6111,30 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-config 1.8.0</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-config 1.8.1</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-credential-types 1.2.10</a></li>
                     <li><a href=" https://github.com/aws/aws-nitro-enclaves-nsm-api ">aws-nitro-enclaves-nsm-api 0.4.0</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-runtime 1.5.8</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-http-client 1.0.5</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-json 0.61.4</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime-api 1.8.1</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-types 1.3.2</a></li>
-                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-xml 0.60.10</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-runtime 1.5.16</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-sigv4 1.3.6</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-async 1.2.6</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-http-client 1.1.4</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-http 0.62.5</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-json 0.61.7</a></li>
+                    <li><a href=" https://github.com/awslabs/smithy-rs ">aws-smithy-observability 0.1.4</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-query 0.60.8</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime-api 1.9.2</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-runtime 1.9.4</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-types 1.3.4</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-smithy-xml 0.60.12</a></li>
+                    <li><a href=" https://github.com/smithy-lang/smithy-rs ">aws-types 1.3.10</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/cms ">cms 0.2.3</a></li>
                     <li><a href=" https://gitlab.com/kornelski/dunce ">dunce 1.0.5</a></li>
                     <li><a href=" https://github.com/starkat99/half-rs ">half 1.8.3</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/target-lexicon ">target-lexicon 0.12.16</a></li>
+                    <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.111</a></li>
+                    <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 2.0.17</a></li>
+                    <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 2.0.17</a></li>
+                    <li><a href=" https://github.com/time-rs/time ">time-core 0.1.6</a></li>
+                    <li><a href=" https://github.com/time-rs/time ">time 0.3.44</a></li>
                 </ul>
                 <pre class="license-text">Apache License
 Version 2.0, January 2004
@@ -6167,7 +6215,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/sfackler/rust-openssl ">openssl 0.10.73</a></li>
+                    <li><a href=" https://github.com/rust-openssl/rust-openssl ">openssl 0.10.75</a></li>
                 </ul>
                 <pre class="license-text">Copyright 2011-2017 Google Inc.
           2013 Jack Lloyd
@@ -6211,7 +6259,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/paholg/typenum ">typenum 1.18.0</a></li>
+                    <li><a href=" https://github.com/paholg/typenum ">typenum 1.19.0</a></li>
                 </ul>
                 <pre class="license-text">MIT OR Apache-2.0</pre>
             </li>
@@ -6265,6 +6313,38 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="ISC">ISC License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.34.0</a></li>
+                </ul>
+                <pre class="license-text">/* Copyright (c) 2018, Google Inc.
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+ * SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+ * OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
+
+#include &lt;openssl/crypto.h&gt;
+
+#include &lt;gtest/gtest.h&gt;
+
+
+TEST(SelfTests, KAT) {
+#if !defined(_MSC_VER)
+  EXPECT_TRUE(BORINGSSL_self_test());
+#endif
+}
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="ISC">ISC License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/briansmith/untrusted ">untrusted 0.7.1</a></li>
                     <li><a href=" https://github.com/briansmith/untrusted ">untrusted 0.9.0</a></li>
                 </ul>
@@ -6308,10 +6388,9 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
                 <h3 id="ISC">ISC License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.13.1</a></li>
-                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.29.0</a></li>
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.15.1</a></li>
                     <li><a href=" https://github.com/rustls/webpki ">rustls-webpki 0.101.7</a></li>
-                    <li><a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.3</a></li>
+                    <li><a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.8</a></li>
                 </ul>
                 <pre class="license-text">ISC License:
 
@@ -6327,7 +6406,7 @@ THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND ISC DISCLAIMS ALL WARRANTIES WITH
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/sfackler/rust-openssl ">openssl-sys 0.9.109</a></li>
+                    <li><a href=" https://github.com/rust-openssl/rust-openssl ">openssl-sys 0.9.111</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014 Alex Crichton
 
@@ -6360,7 +6439,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/mio ">mio 1.0.4</a></li>
+                    <li><a href=" https://github.com/tokio-rs/mio ">mio 1.1.0</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014 Carl Lerche and other MIO contributors
 
@@ -6414,7 +6493,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/hyper ">hyper 1.6.0</a></li>
+                    <li><a href=" https://github.com/hyperium/hyper ">hyper 1.8.1</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014-2025 Sean McArthur
 
@@ -6467,8 +6546,8 @@ SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/h2 ">h2 0.3.26</a></li>
-                    <li><a href=" https://github.com/hyperium/h2 ">h2 0.4.10</a></li>
+                    <li><a href=" https://github.com/hyperium/h2 ">h2 0.3.27</a></li>
+                    <li><a href=" https://github.com/hyperium/h2 ">h2 0.4.12</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2017 h2 authors
 
@@ -6501,7 +6580,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/bytes ">bytes 1.10.1</a></li>
+                    <li><a href=" https://github.com/tokio-rs/bytes ">bytes 1.11.0</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2018 Carl Lerche
 
@@ -6591,7 +6670,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/slab ">slab 0.4.10</a></li>
+                    <li><a href=" https://github.com/tokio-rs/slab ">slab 0.4.11</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2019 Carl Lerche
 
@@ -6657,7 +6736,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-attributes 0.1.29</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-attributes 0.1.30</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-core 0.1.34</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing 0.1.41</a></li>
                 </ul>
@@ -6793,7 +6872,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/hyper-util ">hyper-util 0.1.14</a></li>
+                    <li><a href=" https://github.com/hyperium/hyper-util ">hyper-util 0.1.18</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2023-2025 Sean McArthur
 
@@ -6893,36 +6972,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/KillingSpark/zstd-rs ">ruzstd 0.7.3</a></li>
-                </ul>
-                <pre class="license-text">MIT License
-
-Copyright (c) 2019 Moritz Borcherding
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-macros 2.5.0</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-macros 2.6.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -6982,6 +7032,7 @@ SOFTWARE.</pre>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/Nugine/simd ">base64-simd 0.8.0</a></li>
                     <li><a href=" https://github.com/rust-lang/compiler-builtins ">libm 0.2.15</a></li>
+                    <li><a href=" https://github.com/KillingSpark/zstd-rs ">ruzstd 0.8.2</a></li>
                     <li><a href=" https://github.com/Nugine/simd ">vsimd 0.8.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
@@ -7008,12 +7059,41 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util 0.7.15</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.45.1</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util 0.7.17</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.48.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
 Copyright (c) Tokio Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/mcountryman/simd-adler32 ">simd-adler32 0.3.7</a></li>
+                </ul>
+                <pre class="license-text">MIT License
+
+Copyright (c) [2021] [Marvin Countryman]
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -7066,39 +7146,9 @@ SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-core 0.1.34</a></li>
-                </ul>
-                <pre class="license-text">The MIT License (MIT)
-
-Copyright (c) 2014 Mathijs van de Nes
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/BurntSushi/aho-corasick ">aho-corasick 1.1.3</a></li>
-                    <li><a href=" https://github.com/BurntSushi/byteorder ">byteorder 1.5.0</a></li>
-                    <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.15</a></li>
-                    <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.7.5</a></li>
+                    <li><a href=" https://github.com/BurntSushi/aho-corasick ">aho-corasick 1.1.4</a></li>
+                    <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.16</a></li>
+                    <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.7.6</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -7187,7 +7237,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/shepmaster/twox-hash ">twox-hash 1.6.3</a></li>
+                    <li><a href=" https://github.com/shepmaster/twox-hash ">twox-hash 2.1.2</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -7273,10 +7323,8 @@ SOFTWARE.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/BurntSushi/aho-corasick ">aho-corasick 1.1.3</a></li>
-                    <li><a href=" https://github.com/BurntSushi/byteorder ">byteorder 1.5.0</a></li>
-                    <li><a href=" https://github.com/BurntSushi/jiff ">jiff 0.2.15</a></li>
-                    <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.7.5</a></li>
+                    <li><a href=" https://github.com/BurntSushi/aho-corasick ">aho-corasick 1.1.4</a></li>
+                    <li><a href=" https://github.com/BurntSushi/memchr ">memchr 2.7.6</a></li>
                 </ul>
                 <pre class="license-text">This project is dual-licensed under the Unlicense and MIT licenses.
 
@@ -7315,81 +7363,198 @@ THE SOFTWARE.
                 <h3 id="OpenSSL">OpenSSL License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.29.0</a></li>
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.34.0</a></li>
                 </ul>
-                <pre class="license-text">OpenSSL License
+                <pre class="license-text">/* Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
+ * All rights reserved.
+ *
+ * This package is an SSL implementation written
+ * by Eric Young (eay@cryptsoft.com).
+ * The implementation was written so as to conform with Netscapes SSL.
+ *
+ * This library is free for commercial and non-commercial use as long as
+ * the following conditions are aheared to.  The following conditions
+ * apply to all code found in this distribution, be it the RC4, RSA,
+ * lhash, DES, etc., code; not just the SSL code.  The SSL documentation
+ * included with this distribution is covered by the same copyright terms
+ * except that the holder is Tim Hudson (tjh@cryptsoft.com).
+ *
+ * Copyright remains Eric Young&#x27;s, and as such any Copyright notices in
+ * the code are not to be removed.
+ * If this package is used in a product, Eric Young should be given attribution
+ * as the author of the parts of the library used.
+ * This can be in the form of a textual message at program startup or
+ * in documentation (online or textual) provided with the package.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. All advertising materials mentioning features or use of this software
+ *    must display the following acknowledgement:
+ *    &quot;This product includes cryptographic software written by
+ *     Eric Young (eay@cryptsoft.com)&quot;
+ *    The word &#x27;cryptographic&#x27; can be left out if the rouines from the library
+ *    being used are not cryptographic related :-).
+ * 4. If you include any Windows specific code (or a derivative thereof) from
+ *    the apps directory (application code) you must include an acknowledgement:
+ *    &quot;This product includes software written by Tim Hudson (tjh@cryptsoft.com)&quot;
+ *
+ * THIS SOFTWARE IS PROVIDED BY ERIC YOUNG &#x60;&#x60;AS IS&#x27;&#x27; AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ * The licence and distribution terms for any publically available version or
+ * derivative of this code cannot be changed.  i.e. this code cannot simply be
+ * copied and put under another distribution licence
+ * [including the GNU Public Licence.]
+ */
+/* &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
+ * Copyright (c) 1998-2007 The OpenSSL Project.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. All advertising materials mentioning features or use of this
+ *    software must display the following acknowledgment:
+ *    &quot;This product includes software developed by the OpenSSL Project
+ *    for use in the OpenSSL Toolkit. (http://www.openssl.org/)&quot;
+ *
+ * 4. The names &quot;OpenSSL Toolkit&quot; and &quot;OpenSSL Project&quot; must not be used to
+ *    endorse or promote products derived from this software without
+ *    prior written permission. For written permission, please contact
+ *    openssl-core@openssl.org.
+ *
+ * 5. Products derived from this software may not be called &quot;OpenSSL&quot;
+ *    nor may &quot;OpenSSL&quot; appear in their names without prior written
+ *    permission of the OpenSSL Project.
+ *
+ * 6. Redistributions of any form whatsoever must retain the following
+ *    acknowledgment:
+ *    &quot;This product includes software developed by the OpenSSL Project
+ *    for use in the OpenSSL Toolkit (http://www.openssl.org/)&quot;
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT &#x60;&#x60;AS IS&#x27;&#x27; AND ANY
+ * EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
+ * ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+ * NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ * &#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
+ *
+ * This product includes cryptographic software written by Eric Young
+ * (eay@cryptsoft.com).  This product includes software written by Tim
+ * Hudson (tjh@cryptsoft.com).
+ *
+ */
 
-Copyright (c) 1998-2008 The OpenSSL Project. All rights reserved.
+#include &lt;openssl/ssl.h&gt;
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+#if !defined(OPENSSL_WINDOWS) &amp;&amp; !defined(OPENSSL_PNACL) &amp;&amp; \
+    !defined(OPENSSL_NO_FILESYSTEM)
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+#include &lt;dirent.h&gt;
+#include &lt;errno.h&gt;
+#include &lt;string.h&gt;
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-3. All advertising materials mentioning features or use of this software must display the following acknowledgment: &quot;This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit. (http://www.openssl.org/)&quot;
-
-4. The names &quot;OpenSSL Toolkit&quot; and &quot;OpenSSL Project&quot; must not be used to endorse or promote products derived from this software without prior written permission. For written permission, please contact openssl-core@openssl.org.
-
-5. Products derived from this software may not be called &quot;OpenSSL&quot; nor may &quot;OpenSSL&quot; appear in their names without prior written permission of the OpenSSL Project.
-
-6. Redistributions of any form whatsoever must retain the following acknowledgment: &quot;This product includes software developed by the OpenSSL Project for use in the OpenSSL Toolkit (http://www.openssl.org/)&quot;
-
-THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT &#x60;&#x60;AS IS&#x27;&#x27; AND ANY EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE OpenSSL PROJECT OR ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-This product includes cryptographic software written by Eric Young (eay@cryptsoft.com). This product includes software written by Tim Hudson (tjh@cryptsoft.com).
+#include &lt;openssl/err.h&gt;
+#include &lt;openssl/mem.h&gt;
 
 
-Original SSLeay License
+int SSL_add_dir_cert_subjects_to_stack(STACK_OF(X509_NAME) *stack,
+                                       const char *path) {
+  DIR *dir &#x3D; opendir(path);
+  if (dir &#x3D;&#x3D; NULL) {
+    OPENSSL_PUT_ERROR(SSL, ERR_R_SYS_LIB);
+    ERR_add_error_data(3, &quot;opendir(&#x27;&quot;, dir, &quot;&#x27;)&quot;);
+    return 0;
+  }
 
-Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com) All rights reserved.
+  int ret &#x3D; 0;
+  for (;;) {
+    // |readdir| may fail with or without setting |errno|.
+    errno &#x3D; 0;
+    struct dirent *dirent &#x3D; readdir(dir);
+    if (dirent &#x3D;&#x3D; NULL) {
+      if (errno) {
+        OPENSSL_PUT_ERROR(SSL, ERR_R_SYS_LIB);
+        ERR_add_error_data(3, &quot;readdir(&#x27;&quot;, path, &quot;&#x27;)&quot;);
+      } else {
+        ret &#x3D; 1;
+      }
+      break;
+    }
 
-This package is an SSL implementation written by Eric Young (eay@cryptsoft.com). The implementation was written so as to conform with Netscapes SSL.
+    char buf[1024];
+    if (strlen(path) + strlen(dirent-&gt;d_name) + 2 &gt; sizeof(buf)) {
+      OPENSSL_PUT_ERROR(SSL, SSL_R_PATH_TOO_LONG);
+      break;
+    }
 
-This library is free for commercial and non-commercial use as long as the following conditions are aheared to. The following conditions apply to all code found in this distribution, be it the RC4, RSA, lhash, DES, etc., code; not just the SSL code. The SSL documentation included with this distribution is covered by the same copyright terms except that the holder is Tim Hudson (tjh@cryptsoft.com).
+    int r &#x3D; snprintf(buf, sizeof(buf), &quot;%s/%s&quot;, path, dirent-&gt;d_name);
+    if (r &lt;&#x3D; 0 ||
+        r &gt;&#x3D; (int)sizeof(buf) ||
+        !SSL_add_file_cert_subjects_to_stack(stack, buf)) {
+      break;
+    }
+  }
 
-Copyright remains Eric Young&#x27;s, and as such any Copyright notices in the code are not to be removed. If this package is used in a product, Eric Young should be given attribution as the author of the parts of the library used. This can be in the form of a textual message at program startup or in documentation (online or textual) provided with the package.
+  closedir(dir);
+  return ret;
+}
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the copyright notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-3. All advertising materials mentioning features or use of this software must display the following acknowledgement:
-&quot;This product includes cryptographic software written by Eric Young (eay@cryptsoft.com)&quot;
-The word &#x27;cryptographic&#x27; can be left out if the rouines from the library being used are not cryptographic related :-).
-
-4. If you include any Windows specific code (or a derivative thereof) from the apps directory (application code) you must include an acknowledgement: &quot;This product includes software written by Tim Hudson (tjh@cryptsoft.com)&quot;
-
-THIS SOFTWARE IS PROVIDED BY ERIC YOUNG &#x60;&#x60;AS IS&#x27;&#x27; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-The licence and distribution terms for any publically available version or derivative of this code cannot be changed. i.e. this code cannot simply be copied and put under another distribution licence [including the GNU Public Licence.]
+#endif  // !WINDOWS &amp;&amp; !PNACL &amp;&amp; !OPENSSL_NO_FILESYSTEM
 </pre>
             </li>
             <li class="license">
                 <h3 id="Unicode-3.0">Unicode License v3</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_collections 2.0.0</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_locale_core 2.0.0</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer 2.0.0</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer_data 2.0.0</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties 2.0.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties_data 2.0.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_provider 2.0.0</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">litemap 0.8.0</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">potential_utf 0.1.2</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">tinystr 0.8.1</a></li>
-                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.18</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">writeable 0.6.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke-derive 0.8.0</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke 0.8.0</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_collections 2.1.1</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_locale_core 2.1.1</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer 2.1.1</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_normalizer_data 2.1.1</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties 2.1.1</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_properties_data 2.1.1</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">icu_provider 2.1.1</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">litemap 0.8.1</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">potential_utf 0.1.4</a></li>
+                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.22</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">writeable 0.6.2</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke-derive 0.8.1</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">yoke 0.8.1</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom-derive 0.1.6</a></li>
                     <li><a href=" https://github.com/unicode-org/icu4x ">zerofrom 0.1.6</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerotrie 0.2.2</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerovec-derive 0.11.1</a></li>
-                    <li><a href=" https://github.com/unicode-org/icu4x ">zerovec 0.11.2</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerotrie 0.2.3</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerovec-derive 0.11.2</a></li>
+                    <li><a href=" https://github.com/unicode-org/icu4x ">zerovec 0.11.5</a></li>
                 </ul>
                 <pre class="license-text">UNICODE LICENSE V3
 
@@ -7430,6 +7595,60 @@ Except as contained in this notice, the name of a copyright holder shall
 not be used in advertising or otherwise to promote the sale, use or other
 dealings in these Data Files or Software without prior written
 authorization of the copyright holder.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Unicode-3.0">Unicode License v3</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/unicode-org/icu4x ">tinystr 0.8.2</a></li>
+                </ul>
+                <pre class="license-text">UNICODE LICENSE V3
+
+COPYRIGHT AND PERMISSION NOTICE
+
+Copyright © 2020-2024 Unicode, Inc.
+
+NOTICE TO USER: Carefully read the following legal agreement. BY
+DOWNLOADING, INSTALLING, COPYING OR OTHERWISE USING DATA FILES, AND/OR
+SOFTWARE, YOU UNEQUIVOCALLY ACCEPT, AND AGREE TO BE BOUND BY, ALL OF THE
+TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE, DO NOT
+DOWNLOAD, INSTALL, COPY, DISTRIBUTE OR USE THE DATA FILES OR SOFTWARE.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of data files and any associated documentation (the &quot;Data Files&quot;) or
+software and any associated documentation (the &quot;Software&quot;) to deal in the
+Data Files or Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, and/or sell
+copies of the Data Files or Software, and to permit persons to whom the
+Data Files or Software are furnished to do so, provided that either (a)
+this copyright and permission notice appear with all copies of the Data
+Files or Software, or (b) this copyright and permission notice appear in
+associated Documentation.
+
+THE DATA FILES AND SOFTWARE ARE PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY
+KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF
+THIRD PARTY RIGHTS.
+
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE
+BE LIABLE FOR ANY CLAIM, OR ANY SPECIAL INDIRECT OR CONSEQUENTIAL DAMAGES,
+OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THE DATA
+FILES OR SOFTWARE.
+
+Except as contained in this notice, the name of a copyright holder shall
+not be used in advertising or otherwise to promote the sale, use or other
+dealings in these Data Files or Software without prior written
+authorization of the copyright holder.
+
+SPDX-License-Identifier: Unicode-3.0
+
+—
+
+Portions of ICU4X may have been adapted from ICU4C and/or ICU4J.
+ICU 1.8.1 to ICU 57.1 © 1995-2016 International Business Machines Corporation and others.
 </pre>
             </li>
         </ul>


### PR DESCRIPTION
Auto-generated with cargo-about to update version tracking in THIRD_PARTY_LICENSES_RUST_CRATES.html.

*Description of changes:*

Minor versions of dependencies have been updated in 1.1.0 release, thus bump the versions in the THIRD_PARTY_LICENSES_RUST_CRATES.html using cargo-about.
